### PR TITLE
Implement/Attack direction

### DIFF
--- a/Assets/Animations/Player/Player.controller
+++ b/Assets/Animations/Player/Player.controller
@@ -9,7 +9,7 @@ BlendTree:
   m_Name: Blend Tree
   m_Childs:
   - serializedVersion: 2
-    m_Motion: {fileID: 7400000, guid: 9b412beb033f6834d800a8b8aa068351, type: 2}
+    m_Motion: {fileID: 7400000, guid: 37b166c94ed992343969f244e2d7fcf2, type: 2}
     m_Threshold: 0
     m_Position: {x: 0, y: -1}
     m_TimeScale: 1
@@ -17,16 +17,16 @@ BlendTree:
     m_DirectBlendParameter: Horizontal
     m_Mirror: 0
   - serializedVersion: 2
-    m_Motion: {fileID: 7400000, guid: 37b166c94ed992343969f244e2d7fcf2, type: 2}
-    m_Threshold: 0.16666667
-    m_Position: {x: 0, y: 1}
+    m_Motion: {fileID: 7400000, guid: 9b412beb033f6834d800a8b8aa068351, type: 2}
+    m_Threshold: 1
+    m_Position: {x: 1, y: 0}
     m_TimeScale: 1
     m_CycleOffset: 0
     m_DirectBlendParameter: Horizontal
     m_Mirror: 0
   - serializedVersion: 2
     m_Motion: {fileID: 7400000, guid: 939191efd2a46b64aac4dda4dea4420b, type: 2}
-    m_Threshold: 0.33333334
+    m_Threshold: 2
     m_Position: {x: -1, y: 0}
     m_TimeScale: 1
     m_CycleOffset: 0
@@ -34,43 +34,19 @@ BlendTree:
     m_Mirror: 0
   - serializedVersion: 2
     m_Motion: {fileID: 7400000, guid: 13bb8cb6688f4c640b8ed944b484efaf, type: 2}
-    m_Threshold: 0.5
-    m_Position: {x: 1, y: 0}
+    m_Threshold: 3
+    m_Position: {x: 0, y: 1}
     m_TimeScale: 1
     m_CycleOffset: 0
     m_DirectBlendParameter: Horizontal
     m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 7400000, guid: 9b412beb033f6834d800a8b8aa068351, type: 2}
-    m_Threshold: 0.6666667
-    m_Position: {x: 0, y: 0}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Horizontal
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 7400000, guid: 37b166c94ed992343969f244e2d7fcf2, type: 2}
-    m_Threshold: 0.8333333
-    m_Position: {x: -1, y: 1}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Horizontal
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 7400000, guid: 9b412beb033f6834d800a8b8aa068351, type: 2}
-    m_Threshold: 1
-    m_Position: {x: -1, y: -1}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Horizontal
-    m_Mirror: 0
-  m_BlendParameter: Horizontal
+  m_BlendParameter: FacingDirection
   m_BlendParameterY: Vertical
   m_MinThreshold: 0
-  m_MaxThreshold: 1
-  m_UseAutomaticThresholds: 1
+  m_MaxThreshold: 3
+  m_UseAutomaticThresholds: 0
   m_NormalizedBlendValues: 0
-  m_BlendType: 1
+  m_BlendType: 0
 --- !u!1101 &-8135426220750451335
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -191,17 +167,9 @@ BlendTree:
   m_Name: Blend Tree
   m_Childs:
   - serializedVersion: 2
-    m_Motion: {fileID: 7400000, guid: fc4f524c3c43925409075eeb10a6b0a8, type: 2}
-    m_Threshold: -1
-    m_Position: {x: 0, y: -1}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: Vertical
-    m_Mirror: 0
-  - serializedVersion: 2
     m_Motion: {fileID: 7400000, guid: c5cb8b92933e1f64d963bca1a6aef7d0, type: 2}
     m_Threshold: 1
-    m_Position: {x: 0, y: 1}
+    m_Position: {x: 0.5, y: 1}
     m_TimeScale: 1
     m_CycleOffset: 0
     m_DirectBlendParameter: Vertical
@@ -225,7 +193,7 @@ BlendTree:
   - serializedVersion: 2
     m_Motion: {fileID: 7400000, guid: fc4f524c3c43925409075eeb10a6b0a8, type: 2}
     m_Threshold: 7
-    m_Position: {x: -1, y: -1}
+    m_Position: {x: -0.5, y: -1}
     m_TimeScale: 1
     m_CycleOffset: 0
     m_DirectBlendParameter: Horizontal
@@ -233,7 +201,7 @@ BlendTree:
   - serializedVersion: 2
     m_Motion: {fileID: 7400000, guid: c5cb8b92933e1f64d963bca1a6aef7d0, type: 2}
     m_Threshold: 9
-    m_Position: {x: -1, y: 1}
+    m_Position: {x: -0.5, y: 1}
     m_TimeScale: 1
     m_CycleOffset: 0
     m_DirectBlendParameter: Horizontal
@@ -241,7 +209,7 @@ BlendTree:
   - serializedVersion: 2
     m_Motion: {fileID: 7400000, guid: fc4f524c3c43925409075eeb10a6b0a8, type: 2}
     m_Threshold: 11
-    m_Position: {x: 0, y: 0}
+    m_Position: {x: 0.5, y: -1}
     m_TimeScale: 1
     m_CycleOffset: 0
     m_DirectBlendParameter: Horizontal
@@ -303,6 +271,12 @@ AnimatorController:
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
   - m_Name: Velocity
+    m_Type: 1
+    m_DefaultFloat: 1
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: FacingDirection
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -424,7 +398,7 @@ AnimatorStateTransition:
     m_ConditionEvent: Attacking
     m_EventTreshold: 0
   - m_ConditionMode: 4
-    m_ConditionEvent: Vertical
+    m_ConditionEvent: Velocity
     m_EventTreshold: 0.01
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1266924877529237830}
@@ -498,7 +472,7 @@ AnimatorStateMachine:
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 20, y: -30, z: 0}
   m_EntryPosition: {x: 20, y: 100, z: 0}
-  m_ExitPosition: {x: 320, y: 20, z: 0}
+  m_ExitPosition: {x: 20, y: -90, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 1266924877529237830}
 --- !u!1109 &4508624069379145120

--- a/Assets/Animations/Player/Player.controller
+++ b/Assets/Animations/Player/Player.controller
@@ -78,14 +78,14 @@ BlendTree:
   m_MaxThreshold: 3
   m_UseAutomaticThresholds: 0
   m_NormalizedBlendValues: 0
-  m_BlendType: 0
+  m_BlendType: 1
 --- !u!1101 &-8135426220750451335
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 3
     m_ConditionEvent: Velocity
@@ -168,7 +168,7 @@ AnimatorStateTransition:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 2
     m_ConditionEvent: Attacking
@@ -259,7 +259,7 @@ AnimatorStateTransition:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 4
     m_ConditionEvent: Velocity
@@ -307,7 +307,7 @@ AnimatorController:
     m_DefaultFloat: 1
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: FacingDirection
     m_Type: 1
     m_DefaultFloat: 0
@@ -362,18 +362,18 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: -7151337008155013061}
-  m_Tag:
-  m_SpeedParameter:
-  m_MirrorParameter:
-  m_CycleOffsetParameter:
-  m_TimeParameter:
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &2286503756286530766
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Attacking
@@ -413,18 +413,18 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 804645ad3a5ec6f4e828efe3ed9b2480, type: 2}
-  m_Tag:
-  m_SpeedParameter:
-  m_MirrorParameter:
-  m_CycleOffsetParameter:
-  m_TimeParameter:
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &2583794053682259065
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 2
     m_ConditionEvent: Attacking
@@ -452,7 +452,7 @@ AnimatorStateTransition:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 4
     m_ConditionEvent: Velocity
@@ -513,7 +513,7 @@ AnimatorTransition:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions: []
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1266924877529237830}
@@ -527,7 +527,7 @@ AnimatorStateTransition:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Attacking
@@ -569,11 +569,11 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: -8243801370232131224}
-  m_Tag:
-  m_SpeedParameter:
-  m_MirrorParameter:
-  m_CycleOffsetParameter:
-  m_TimeParameter:
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &8367611969718872713
 AnimatorState:
   serializedVersion: 6
@@ -597,18 +597,18 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: -761513903596780875}
-  m_Tag:
-  m_SpeedParameter:
-  m_MirrorParameter:
-  m_CycleOffsetParameter:
-  m_TimeParameter:
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &8382077343686230935
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Attacking
@@ -633,7 +633,7 @@ AnimatorStateTransition:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: Dead

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -106,7 +106,7 @@ namespace Player
             Right,
         }
 
-        private FacingDirection facingDirection;
+        private FacingDirection facingDirection = FacingDirection.Up;
 
         public FacingDirection GetFacingDirection()
         {

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -137,9 +137,9 @@ namespace Player
                     // Only if stick is in use
                     if (playerAttack != Vector2.zero)
                     {
-                        //playerAttack <-- Use this Vector2 for player-to-enemy direction
                         // Face direction and Attack!
                         attacking = true;
+                        facingDirection = CalculateFacingDirection(playerAttack);
                     }
                 }
                 // Keyboard controls
@@ -156,6 +156,7 @@ namespace Player
 
                         // Attack!
                         attacking = true;
+                        facingDirection = CalculateFacingDirection(attackDirection);
                     }
                 }
 
@@ -194,10 +195,10 @@ namespace Player
         // Declare an attack.
         private void Attack()
         {
+            attacking = false;
             attackOnCooldown = true;
             _weapon.DoAttack();
             StartCoroutine(ResetAttackCooldown());
-            attacking = false;
         }
 
         // This function resets the attack cooldown after the cooldown period ends.
@@ -205,6 +206,22 @@ namespace Player
         {
             yield return new WaitForSeconds(1 / attackSpeedActual);
             attackOnCooldown = false;
+        }
+
+        private static FacingDirection CalculateFacingDirection(Vector2 direction)
+        {
+            // If the absolute value of X is larger than Y.
+            if (Mathf.Abs(direction.x) > Mathf.Abs(direction.y))
+            {
+                // If X is positive, the facing direction is Right. Otherwise it is Left.
+                return (direction.x > 0F ? FacingDirection.Right : FacingDirection.Left);
+            }
+            // else, the absolute value of Y is larger.
+            else
+            {
+                // If Y is positive, the facing direction is Up. Otherwise it is Down.
+                return (direction.y > 0F ? FacingDirection.Up : FacingDirection.Down);
+            }
         }
 
         private void RecalculateStats()

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -126,34 +126,35 @@ namespace Player
         // Update is called once per frame
         private void Update()
         {
+            // Check if the player can be moved.
             if (Controllers.GameController.IsPlayerInputEnabled)
             {
-                // If user is left-clicking.
-                // TODO Replace this check for analog 2.
-                if (Controllers.InputController.isMobile) //Mobile Controls
+                // Mobile Controls
+                if (Controllers.InputController.isMobile)
                 {
                     Vector2 playerAttack = playerInput.actions["Attack"].ReadValue<Vector2>();
 
-                    //Only if stick is in use
+                    // Only if stick is in use
                     if (playerAttack != Vector2.zero)
                     {
-                        //Face direction and Attack!
                         //playerAttack <-- Use this Vector2 for player-to-enemy direction
+                        // Face direction and Attack!
                         attacking = true;
                     }
                 }
-                else //keyboard controls
+                // Keyboard controls
+                else
                 {
-                    //Attack is pressed
+                    // Attack is pressed
                     if (playerInput.actions["Attack"].IsPressed())
                     {
-                        //Attack in direction of the mouse
+                        // Attack in direction of the mouse
                         Vector2 mousePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
                         Vector2 attackDirection = mousePosition - (Vector2) transform.position;
-                        //Final attack direction to face player to mouse
+                        // Final attack direction to face player to mouse
                         attackDirection = transform.position + (Vector3) attackDirection;
 
-                        //Attack!
+                        // Attack!
                         attacking = true;
                     }
                 }

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -160,6 +160,21 @@ namespace Player
 
                 // Update the animator.
                 animator.SetBool("Attacking", attacking);
+                switch (facingDirection)
+                {
+                    case FacingDirection.Up:
+                        animator.SetFloat("FacingDirection", 0F);
+                        break;
+                    case FacingDirection.Down:
+                        animator.SetFloat("FacingDirection", 1F);
+                        break;
+                    case FacingDirection.Left:
+                        animator.SetFloat("FacingDirection", 2F);
+                        break;
+                    case FacingDirection.Right:
+                        animator.SetFloat("FacingDirection", 3F);
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
The following changes have been approached:

- The player animations when attacking use the FacingDirection value instead of the Horizontal and Vertical movement values
This is to allow the player to face in the correct direction while attacking (when not attacking, other animation units kick-in).
- The player attack-control code calculates the closest cardinal direction that the player is facing in, depending on the control type that is being used.
This allows both the above animation to be fed the correct data, and for future-use with weapon attack hit registration.